### PR TITLE
fix: remove top-margin to fix dropdown content

### DIFF
--- a/style.css
+++ b/style.css
@@ -53,7 +53,7 @@ header {
     box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.2);
     min-width: 160px;
     z-index: 1;
-    margin-top: 10px;
+    padding-top: 10px;
 }
 
 .dropdown-content a {


### PR DESCRIPTION
If you want to have an empty space between elements then css alone won't help here. JS will be required for that :)

Correct me if I'm wrong.